### PR TITLE
Nouvelles disciplines et transformation du personnel

### DIFF
--- a/chargement/unites.py
+++ b/chargement/unites.py
@@ -9,14 +9,14 @@ from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(description='Script pour charger les données de programmes dans l\'entrepôt')
+    parser = argparse.ArgumentParser(description='Script pour charger les données des unités dans l\'entrepôt')
     parser.add_argument('--fichier', required=True, help='Chemin du fichier CSV à charger')
     return parser.parse_args()
 
 
 # Configuration du journal
 initialisation_logs()
-logger = logging.getLogger("chargement/programmes.py")
+logger = logging.getLogger("chargement/unites.py")
 
 # Les arguments en ligne de commande
 args = parse_arguments()
@@ -24,11 +24,7 @@ args = parse_arguments()
 # Chemin du fichier CSV à charger
 chemin_fichier_csv = args.fichier
 
-# Nom de la table dans la base de données
-# Elle sera vidée avant le chargement
-nom_table = "programmes"
-
-logger.info(f"Début du chargement des programmes depuis le fichier {chemin_fichier_csv}")
+logger.info(f"Début du chargement des disciplines depuis le fichier {chemin_fichier_csv}")
 
 try:
 
@@ -36,12 +32,12 @@ try:
     connexion = se_connecter_a_la_base_de_donnees(logger)
 
     # On commence par supprimer toute donnée dans la table
-    requete = f"DELETE FROM {nom_table};"
+    requete = "DELETE FROM unites;"
     executer_requete(connexion, requete, logger)
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        COPY unites
         (code, nom, discipline)
         FROM '{chemin_fichier_csv}'
         DELIMITER ';'

--- a/utils/creation.py
+++ b/utils/creation.py
@@ -34,11 +34,11 @@ try:
         # Création de la table
         requete = f"""
             CREATE TABLE {nom_table} (
+                id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 ),
                 code VARCHAR(50),
-                nom VARCHAR(255),
-                departement VARCHAR(255),
+                nom VARCHAR(255) NULL,
                 discipline VARCHAR(255),
-                CONSTRAINT pkey_{nom_table} PRIMARY KEY (code)
+                CONSTRAINT pkey_{nom_table} PRIMARY KEY (id)
             );
         """
         executer_requete(connexion, requete, logger)
@@ -59,6 +59,25 @@ try:
                 bibliothecaire VARCHAR(255),
                 bibliotheque VARCHAR(255),
                 CONSTRAINT pkey_{nom_table} PRIMARY KEY (discipline, bibliothecaire)
+            );
+        """
+        executer_requete(connexion, requete, logger)
+
+
+    # La table des unités
+    if (domaines.getboolean('domaines', 'unites')):
+        logger.info("Début de la création de la table des unités")
+
+        # On supprime la table si elle existe
+        executer_requete(connexion, "DROP TABLE IF EXISTS unites", logger)
+
+        # Création de la table
+        requete = """
+            CREATE TABLE unites (
+                code VARCHAR(255),
+                nom VARCHAR(255),
+                discipline VARCHAR(255),
+                CONSTRAINT pkey_unites PRIMARY KEY (code)
             );
         """
         executer_requete(connexion, requete, logger)
@@ -326,6 +345,7 @@ try:
                 CodeBarres VARCHAR(50),
                 Fonction VARCHAR(255),
                 Login VARCHAR(100),
+                niveau VARCHAR(50),
                 journee DATE,
                 discipline VARCHAR(255),
                 bibliotheque VARCHAR(100),


### PR DESCRIPTION
Plusieurs modifications ont été apportées pour:

1. Tenir compte d'une nouvelle liste de disciplines
2. Ajouter la correspondance entre les unités et les disciplines pour le personnel

Il faut donc:

1. Créer de nouveau les tables des domaines programmes, synchro, disciplines, unites
2. Faire les chargements: disciplines, étudiants, personnel, programmes, unites
3. Faire les transformations: clientèles

Le tout devrait être cohérent ensuite, avec une table _clientele_cumul qui contient les étudiants et le personnel.