### PR TITLE
Changements pour exécuter depuis la racine et un fichier de config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 *.pyc
 
 # Les fichiers de config cachés
-config/_*.ini
+_*.ini
 
 # Les logs
 logs/*.log

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ce dépôt contient différents script pour extraire et manipuler les données d
 
 ### Connexion à la base de données
 
-Un fichier de configuration `config/_db.ini` doit contenir les informations de connexion à la base de données. Il n'est pas dans l'entrepôt Git pour ne pas exposer ces informations.
+Un fichier de configuration `_config.ini` doit contenir les informations de connexion à la base de données. Il n'est pas dans l'entrepôt Git pour ne pas exposer ces informations.
 
 Voici un exemple de fichier:
 
@@ -23,11 +23,11 @@ port = 5432
 
 Les différents scripts utlisent un journal (logs) commun.
 
-C'est le fichier `config/_logs.ini` qui contient les informations, et il doit avoir ces informations:
+C'est le fichier `_config.ini` qui contient les informations, et il doit avoir ces informations:
 
 ```ini
 [logs]
-fichier = ../logs/entrepot.log
+fichier = logs/entrepot.log
 niveau = INFO
 ```
 
@@ -48,7 +48,7 @@ reservations = TRUE
 
 Pour chaque domaine de données, si la valeur est TRUE, les tables seront supprimées et recréées. S'il est à FALSE, elles ne seront pas touchées.
 
-Une fois ce fichier créé, et les informations de connexion à la base de données bien inscrites dans `config/_db.ini`, on peut exécuter le script sans paramètres:
+Une fois ce fichier créé, et les informations de connexion à la base de données bien inscrites dans `_config.ini`, on peut exécuter le script sans paramètres:
 
 ```bash
 python creation.py

--- a/chargement/disciplines.py
+++ b/chargement/disciplines.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/etudiants.py
+++ b/chargement/etudiants.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/evenements.py
+++ b/chargement/evenements.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/frequentation.py
+++ b/chargement/frequentation.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/inscriptions.py
+++ b/chargement/inscriptions.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/ordinateurs.py
+++ b/chargement/ordinateurs.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/personnel.py
+++ b/chargement/personnel.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/programmes.py
+++ b/chargement/programmes.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/reservations.py
+++ b/chargement/reservations.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/synonymes.py
+++ b/chargement/synonymes.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/unites.py
+++ b/chargement/unites.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/chargement/verifications.py
+++ b/chargement/verifications.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 

--- a/commun/courriel.py
+++ b/commun/courriel.py
@@ -8,7 +8,7 @@ def envoyer_courriel(objet, contenu, logger):
 
     # Configuration courriel
     config = configparser.ConfigParser()
-    config.read('../config/_courriel.ini')
+    config.read('_config.ini')
 
     if (config.getboolean('email', 'envoyer')):
 

--- a/commun/db.py
+++ b/commun/db.py
@@ -7,7 +7,7 @@ def se_connecter_a_la_base_de_donnees(logger):
 
     # Configuration de la base de données
     config = configparser.ConfigParser()
-    config.read('../config/_db.ini')
+    config.read('_config.ini')
 
     try:
         conn = psycopg2.connect(
@@ -50,12 +50,12 @@ def executer_requete_select(cursor, requete_sql, logger):
 
 def prefixe_sha256():
     config = configparser.ConfigParser()
-    config.read('../config/_db.ini')
+    config.read('_config.ini')
     return config['database']['prefixe']
 
 def suffixe_sha256():
     config = configparser.ConfigParser()
-    config.read('../config/_db.ini')
+    config.read('_config.ini')
     return config['database']['suffixe']
 
 def cursor2csv(resultats, noms_colonnes, sep = "\t"):

--- a/commun/logs.py
+++ b/commun/logs.py
@@ -5,5 +5,5 @@ logger = logging.getLogger
 
 def initialisation_logs():
     journalisation = configparser.ConfigParser()
-    journalisation.read('../config/_logs.ini')
+    journalisation.read('_config.ini')
     logging.basicConfig(filename=journalisation['logs']['fichier'], level=getattr(logging, journalisation['logs']['niveau']), format='%(asctime)s - %(levelname)s: [%(name)s] %(message)s')

--- a/extraction/etudiants.py
+++ b/extraction/etudiants.py
@@ -4,7 +4,7 @@ import configparser
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 
 def parse_arguments():

--- a/extraction/evenements_inscriptions.py
+++ b/extraction/evenements_inscriptions.py
@@ -6,7 +6,7 @@ import logging
 import configparser
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 
 def obtenir_token(url_token, client_id, client_secret):
@@ -84,7 +84,7 @@ logger = logging.getLogger("extraction/inscriptions.py")
 
 # Accès LibCal
 config = configparser.ConfigParser()
-config.read('../config/_libcal.ini')
+config.read('_config.ini')
 
 # Les arguments en ligne de commande
 args = parse_arguments()

--- a/extraction/frequentation.py
+++ b/extraction/frequentation.py
@@ -5,7 +5,7 @@ import configparser
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 
 def parse_arguments():
@@ -23,13 +23,13 @@ logger.info(f"Début de l'extraction des données de fréquentation et d'occupat
 
 # Configuration de l'accès à la base de données
 config = configparser.ConfigParser()
-config.read('../config/_frequentation.ini')
+config.read('_config.ini')
 
 # Lest arguments en ligne de commande
 args = parse_arguments()
 
 # Établir une connexion à la base de données
-conn_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={config['sqlserver']['server']};DATABASE={config['sqlserver']['database']};UID={config['sqlserver']['username']};PWD={config['sqlserver']['password']};TrustServerCertificate=yes"
+conn_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={config['sqlserver-freq']['server']};DATABASE={config['sqlserver-freq']['database']};UID={config['sqlserver-freq']['username']};PWD={config['sqlserver-freq']['password']};TrustServerCertificate=yes"
 conn = pyodbc.connect(conn_string)
 
 # Créer un curseur

--- a/extraction/ordinateurs.py
+++ b/extraction/ordinateurs.py
@@ -5,7 +5,7 @@ import configparser
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 
 def parse_arguments():
@@ -23,13 +23,13 @@ logger.info(f"Début de l'extraction des données d'utilisation des postes publi
 
 # Configuration de l'accès à la base de données
 config = configparser.ConfigParser()
-config.read('../config/_ordinateurs.ini')
+config.read('_config.ini')
 
 # Lest arguments en ligne de commande
 args = parse_arguments()
 
 # Établir une connexion à la base de données
-conn_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={config['sqlserver']['server']};DATABASE={config['sqlserver']['database']};UID={config['sqlserver']['username']};PWD={config['sqlserver']['password']};TrustServerCertificate=yes"
+conn_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={config['sqlserver-ordinateurs']['server']};DATABASE={config['sqlserver-ordinateurs']['database']};UID={config['sqlserver-ordinateurs']['username']};PWD={config['sqlserver-ordinateurs']['password']};TrustServerCertificate=yes"
 conn = pyodbc.connect(conn_string)
 
 # Créer un curseur

--- a/extraction/personnel.py
+++ b/extraction/personnel.py
@@ -4,7 +4,7 @@ import configparser
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 
 def parse_arguments():

--- a/extraction/salles-reservations.py
+++ b/extraction/salles-reservations.py
@@ -6,7 +6,7 @@ import logging
 import configparser
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 
 def obtenir_token(url_token, client_id, client_secret):
@@ -103,7 +103,7 @@ logger = logging.getLogger("extraction/salles-reservations.py")
 
 # Accès LibCal
 config = configparser.ConfigParser()
-config.read('../config/_libcal.ini')
+config.read('_config.ini')
 
 # Les arguments en ligne de commande
 args = parse_arguments()

--- a/transformation/clienteles.py
+++ b/transformation/clienteles.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, prefixe_sha256, suffixe_sha256, cursor2csv, executer_requete_select
 from courriel import envoyer_courriel

--- a/transformation/frequentation_occupation.py
+++ b/transformation/frequentation_occupation.py
@@ -4,7 +4,7 @@ import logging
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, cursor2csv, executer_requete_select
 from courriel import envoyer_courriel

--- a/transformation/reservations.py
+++ b/transformation/reservations.py
@@ -4,7 +4,7 @@ import psycopg2
 import argparse
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, prefixe_sha256, suffixe_sha256, cursor2csv, executer_requete_select
 from courriel import envoyer_courriel

--- a/utils/creation.py
+++ b/utils/creation.py
@@ -3,7 +3,7 @@ import psycopg2
 import logging
 import sys
 import os
-sys.path.append(os.path.abspath("../commun"))
+sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
 from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
 
@@ -13,7 +13,7 @@ logger = logging.getLogger("utils/creation.py")
 
 # Domaines à créer/supprimer
 domaines = configparser.ConfigParser()
-domaines.read('../config/_creation.ini')
+domaines.read('_config.ini')
 
 # Requêtes de création de tables
 try:

--- a/utils/pilote_quotidien.py
+++ b/utils/pilote_quotidien.py
@@ -19,7 +19,7 @@ def parse_arguments():
 
 args = parse_arguments()
 config = configparser.ConfigParser()
-config.read('../config/_quotidien.ini')
+config.read('_config.ini')
 
 dossier_sortie = os.path.abspath(args.dossier_temp)
 if not (os.path.exists(dossier_sortie) and os.path.isdir(dossier_sortie) and os.access(dossier_sortie, os.W_OK)):
@@ -39,15 +39,13 @@ journee_actuelle = datetime.now().strftime("%Y-%m-%d")
 # Extraction des données
 journee_extraction = (datetime.strptime(journee_actuelle, "%Y-%m-%d") - timedelta(days=1)).strftime("%Y-%m-%d")
 fichier_csv = f"{dossier_sortie}{os.path.sep}ordinateurs-{journee_extraction}.csv"
-script = "../extraction/ordinateurs.py"
-dossier_script = os.path.dirname(script)
-resultat = subprocess.run(["python", script, "--date_debut", journee_extraction, "--date_fin", journee_extraction, "--fichier_sortie", fichier_csv], cwd=dossier_script, capture_output=True, text=True)
+script = "extraction/ordinateurs.py"
+resultat = subprocess.run(["python", script, "--date_debut", journee_extraction, "--date_fin", journee_extraction, "--fichier_sortie", fichier_csv], capture_output=True, text=True)
 #TODO: gestion des erreurs avec resultat.returncode et resultat.stdout (ou stderr)
 
 # Chargement des données
-script = "../chargement/ordinateurs.py"
-dossier_script = os.path.dirname(script)
-resultat = subprocess.run(["python", script, "--fichier", fichier_csv], cwd=dossier_script, capture_output=True, text=True)
+script = "chargement/ordinateurs.py"
+resultat = subprocess.run(["python", script, "--fichier", fichier_csv], capture_output=True, text=True)
 #TODO: gestion des erreurs avec resultat.returncode et resultat.stdout (ou stderr)
 
 # Transformation des données
@@ -63,37 +61,32 @@ resultat = subprocess.run(["python", script, "--fichier", fichier_csv], cwd=doss
 
 # Extraction des données
 
-fichier_synchro = config['clienteles']['synchro_ac']
+fichier_synchro = config['quotidien']['synchro_ac']
 fichier_csv_ac = f"{dossier_sortie}{os.path.sep}etudiants.csv"
-script = "../extraction/etudiants.py"
-dossier_script = os.path.dirname(script)
-resultat = subprocess.run(["python", script, "--fichier_entree", fichier_synchro, "--fichier_sortie", fichier_csv_ac], cwd=dossier_script, capture_output=True, text=True)
+script = "extraction/etudiants.py"
+resultat = subprocess.run(["python", script, "--fichier_entree", fichier_synchro, "--fichier_sortie", fichier_csv_ac], capture_output=True, text=True)
 #TODO: gestion des erreurs avec resultat.returncode et resultat.stdout (ou stderr)
 
-fichier_synchro = config['clienteles']['synchro_rh']
+fichier_synchro = config['quotidien']['synchro_rh']
 fichier_csv_rh = f"{dossier_sortie}{os.path.sep}personnel.csv"
-script = "../extraction/personnel.py"
-dossier_script = os.path.dirname(script)
-resultat = subprocess.run(["python", script, "--fichier_entree", fichier_synchro, "--fichier_sortie", fichier_csv_rh], cwd=dossier_script, capture_output=True, text=True)
+script = "extraction/personnel.py"
+resultat = subprocess.run(["python", script, "--fichier_entree", fichier_synchro, "--fichier_sortie", fichier_csv_rh], capture_output=True, text=True)
 #TODO: gestion des erreurs avec resultat.returncode et resultat.stdout (ou stderr)
 
 # Chargement des données
 
 journee_extraction = (datetime.strptime(journee_actuelle, "%Y-%m-%d") - timedelta(days=1)).strftime("%Y-%m-%d")
 
-script = "../chargement/etudiants.py"
-dossier_script = os.path.dirname(script)
-resultat = subprocess.run(["python", script, "--jour", journee_extraction, "--fichier", fichier_csv_ac], cwd=dossier_script, capture_output=True, text=True)
+script = "chargement/etudiants.py"
+resultat = subprocess.run(["python", script, "--jour", journee_extraction, "--fichier", fichier_csv_ac], capture_output=True, text=True)
 #TODO: gestion des erreurs avec resultat.returncode et resultat.stdout (ou stderr)
 
-script = "../chargement/personnel.py"
-dossier_script = os.path.dirname(script)
-resultat = subprocess.run(["python", script, "--jour", journee_extraction, "--fichier", fichier_csv_rh], cwd=dossier_script, capture_output=True, text=True)
+script = "chargement/personnel.py"
+resultat = subprocess.run(["python", script, "--jour", journee_extraction, "--fichier", fichier_csv_rh], capture_output=True, text=True)
 #TODO: gestion des erreurs avec resultat.returncode et resultat.stdout (ou stderr)
 
 # Transformation des données
 
-script = "../transformation/clienteles.py"
-dossier_script = os.path.dirname(script)
-resultat = subprocess.run(["python", script], cwd=dossier_script, capture_output=True, text=True)
+script = "transformation/clienteles.py"
+resultat = subprocess.run(["python", script], capture_output=True, text=True)
 #TODO: gestion des erreurs avec resultat.returncode et resultat.stdout (ou stderr)


### PR DESCRIPTION
Beaucoup de petits changements, mais à retenir:

1. On doit exécuter les scripts depuis le dossier racine, par exemple "python transformation/clienteles.py"
2. Il y a un seul fichier de config, _config.ini, à la racine. Voir exemple dans Teams.