### PR TITLE
Retrait de l'utilisation de COPY TO... FROM... pour charger les données CSV

### DIFF
--- a/chargement/disciplines.py
+++ b/chargement/disciplines.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données de disciplines dans l\'entrepôt')
@@ -41,13 +41,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (discipline, bibliothecaire, bibliotheque)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ';'
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger)
 
     # Ajout du secteur de la bibliothèque
     requete = f"""

--- a/chargement/emprunts.py
+++ b/chargement/emprunts.py
@@ -7,7 +7,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données des emprunts de documents WMS dans l\'entrepôt')
@@ -41,16 +41,13 @@ try:
     executer_requete(connexion, requete, logger)
 
     # Ensuite on charge les données
-    #cb_document	cote	bibliotheque_pret	cb_usager	date	bibliotheque_document	institution_doc	institution_usager
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (cb_document, cote, bibliotheque_pret, cb_usager, date, bibliotheque_document, institution_doc, institution_usager)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER '\t'
-        CSV HEADER
-        WHERE date IS NOT NULL; -- Ajout d'une condition pour ignorer les lignes où la date est NULL
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, "\t")
+
 
 finally:
     # On ferme la connexion

--- a/chargement/etudiants.py
+++ b/chargement/etudiants.py
@@ -7,7 +7,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données des étudiants dans l\'entrepôt')
@@ -42,13 +42,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (codebarres, codeCycle, codeProgramme, programme, courriel, login)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, ",")
 
     # On va ajuster la date du jour
     jour = args.jour

--- a/chargement/evenements.py
+++ b/chargement/evenements.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les événements de formation dans l\'entrepôt')
@@ -35,15 +35,12 @@ try:
     connexion = se_connecter_a_la_base_de_donnees(logger)
 
     # Ensuite on charge les données
-    # id,title,start,end,owner.name,presenter
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (id, title, start, finish, owner, presenter)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, ",")
 
 finally:
     # On ferme la connexion

--- a/chargement/frequentation.py
+++ b/chargement/frequentation.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données de fréquentation et d\'occupation dans l\'entrepôt')
@@ -43,13 +43,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (Enregistrement, Secteur, Date, Entrees)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, ",")
 
     ## Occupation
 
@@ -67,13 +65,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (Enregistrement, Secteur, Date, Occupation)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, ",")
 
 finally:
     # On ferme la connexion

--- a/chargement/inscriptions.py
+++ b/chargement/inscriptions.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, prefixe_sha256, suffixe_sha256, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, prefixe_sha256, suffixe_sha256, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données d\'inscription aux formations dans l\'entrepôt')
@@ -40,16 +40,13 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (event_id, booking_id, registration_type, email)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, ",")
 
     # On transforme la forme du courriel pour le rendred illisible
-    # On copie proprietaire dans presentateur si ce dernier est 'null'
     requete = f"""
         UPDATE {nom_table}
         SET email = sha256(concat('{prefixe}', email, '{suffixe}')::bytea)::varchar;

--- a/chargement/ordinateurs.py
+++ b/chargement/ordinateurs.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données d\'utilisation des ordinateurs publics dans l\'entrepôt')
@@ -40,13 +40,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (ID, Secteur, Station, Utilisateur_Login, Ouverture_session, Fermeture_session, Duree)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, ",")
 
 finally:
     # On ferme la connexion

--- a/chargement/personnel.py
+++ b/chargement/personnel.py
@@ -7,7 +7,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données du personnel dans l\'entrepôt')
@@ -42,13 +42,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (CodeUnite, DescUnite, Statut, Courriel, CodeBarres, Fonction, Login)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, ",")
 
     # On va ajuster la date du jour
     jour = args.jour

--- a/chargement/programmes.py
+++ b/chargement/programmes.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données de programmes dans l\'entrepôt')
@@ -41,13 +41,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (code, nom, discipline)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ';'
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger)
 
 finally:
     # On ferme la connexion

--- a/chargement/programmes_laval.py
+++ b/chargement/programmes_laval.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données de programmes dans l\'entrepôt')
@@ -28,7 +28,7 @@ chemin_fichier_csv = args.fichier
 # Elle sera vidée avant le chargement
 nom_table = "programmes_laval"
 
-logger.info(f"Début du chargement des programmes depuis le fichier {chemin_fichier_csv}")
+logger.info(f"Début du chargement des programmes de Laval depuis le fichier {chemin_fichier_csv}")
 
 try:
 
@@ -41,13 +41,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (codeprogramme, code, nom, discipline)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ';'
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger)
 
 finally:
     # On ferme la connexion

--- a/chargement/reservations.py
+++ b/chargement/reservations.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données de réservation de salles dans l\'entrepôt')
@@ -34,15 +34,13 @@ try:
     # Connexion à la base de données
     connexion = se_connecter_a_la_base_de_donnees(logger)
 
-    # On charge les données
+    # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (fromDate, email, status, location_name, category_name, item_name)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger)
 
 finally:
     # On ferme la connexion

--- a/chargement/secteurs.py
+++ b/chargement/secteurs.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données de secteurs dans l\'entrepôt')
@@ -28,7 +28,7 @@ chemin_fichier_csv = args.fichier
 # Elle sera vidée avant le chargement
 nom_table = "secteurs"
 
-logger.info(f"Début du chargement des disciplines depuis le fichier {chemin_fichier_csv}")
+logger.info(f"Début du chargement des secteurs depuis le fichier {chemin_fichier_csv}")
 
 try:
 
@@ -41,14 +41,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (bibliotheque, secteur)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ';'
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
-
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger)
 
 finally:
     # On ferme la connexion

--- a/chargement/synonymes.py
+++ b/chargement/synonymes.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger des synomymes dans l\'entrepôt')
@@ -35,15 +35,17 @@ try:
 
     logger.info(f"Début du chargement des synonymes depuis le fichier {chemin_fichier_csv}")
 
-    # On charge les données
-    requete = f"""
-        COPY {nom_table}
-        (domaine, rejeter, accepter)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER '\t'
-        CSV HEADER;
-    """
+    # On commence par supprimer toute donnée dans la table
+    requete = f"DELETE FROM {nom_table};"
     executer_requete(connexion, requete, logger)
+
+    # Ensuite on charge les données
+    requete = f"""
+        INSERT INTO {nom_table}
+        (domaine, rejeter, accepter)
+        VALUES %s
+    """
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, "\t")
 
 finally:
     # On ferme la connexion

--- a/chargement/unites.py
+++ b/chargement/unites.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données des unités dans l\'entrepôt')
@@ -37,13 +37,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY unites
+        INSERT INTO unites
         (code, nom, discipline)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ';'
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger)
 
 finally:
     # On ferme la connexion

--- a/chargement/verifications.py
+++ b/chargement/verifications.py
@@ -6,7 +6,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("commun"))
 from logs import initialisation_logs
-from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete
+from db import se_connecter_a_la_base_de_donnees, fermer_connexion, executer_requete, copy_from_csv
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Script pour charger les données de vérification dans l\'entrepôt')
@@ -42,13 +42,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (cycle)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ';'
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger)
 
     # Les status de réservation
     chemin_fichier_csv = args.fichier_statuts_reservations
@@ -65,13 +63,11 @@ try:
 
     # Ensuite on charge les données
     requete = f"""
-        COPY {nom_table}
+        INSERT INTO {nom_table}
         (nom, conserver)
-        FROM '{chemin_fichier_csv}'
-        DELIMITER ','
-        CSV HEADER;
+        VALUES %s
     """
-    executer_requete(connexion, requete, logger)
+    copy_from_csv(connexion, requete, chemin_fichier_csv, logger, ",")
 
 finally:
     # On ferme la connexion


### PR DESCRIPTION
Pour éviter que le serveur PostgreSQL ait besoin d'avoir accès aux fichiers. Maintenant ce sont les scripts Python qui lisent les fichiers.