### PR TITLE
Changement de la clé primaire des emprunts pour faire les traitements en SQL

### DIFF
--- a/transformation/emprunts.py
+++ b/transformation/emprunts.py
@@ -33,6 +33,10 @@ try:
     # Travail sur la table temporaire des réservations
     logger.info("Début de la transformation des données sur les emprunts")
 
+    # On supprime les lignes sans date
+    requete = "DELETE FROM _tmp_emprunts WHERE date IS NULL OR date = '';"
+    executer_requete(connexion, requete, logger)
+
     # On vérifie si on a les bons noms d'institutions
 #    requete = """
 #        SELECT DISTINCT institution
@@ -60,6 +64,8 @@ try:
     #"""
     #        envoyer_courriel("Entrepôt de données - Nouvelles institutions pour les emprunts", intro + res, logger)
     #        sys.exit(1)
+
+# WHERE date IS NOT NULL; -- Ajout d'une condition pour ignorer les lignes où la date est NULL
 
     # Vérification et correction des noms d'institutions
     requete = """

--- a/utils/creation.py
+++ b/utils/creation.py
@@ -490,6 +490,7 @@ try:
         # Création de la table
         requete = f"""
             CREATE TABLE {tmp_prefixe}{nom_table} (
+                id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 ),
                 cb_document VARCHAR(255),
                 cote VARCHAR(255),
                 bibliotheque_pret VARCHAR(255),
@@ -497,8 +498,7 @@ try:
                 date VARCHAR(255),
                 bibliotheque_document VARCHAR(255),
                 institution_doc VARCHAR(255),
-                institution_usager VARCHAR(255),
-                CONSTRAINT pkey_tmp_emprunts PRIMARY KEY (cb_document, cb_usager, date)
+                institution_usager VARCHAR(255)
             );
         """
         executer_requete(connexion, requete, logger)


### PR DESCRIPTION
En ajoutant une clé primaire 'id', on peut charger des dates vides. Elles seront supprimées lors de la transformation.