### PR TITLE
Modifications pour éviter les erreurs de duplication des clés primaires

### DIFF
--- a/chargement/evenements.py
+++ b/chargement/evenements.py
@@ -34,6 +34,10 @@ try:
     # Connexion à la base de données
     connexion = se_connecter_a_la_base_de_donnees(logger)
 
+    # On supprime les données temporaires
+    requete = f"DELETE FROM {nom_table}"
+    executer_requete(connexion, requete, logger)
+
     # Ensuite on charge les données
     requete = f"""
         INSERT INTO {nom_table}

--- a/chargement/inscriptions.py
+++ b/chargement/inscriptions.py
@@ -38,6 +38,10 @@ try:
     # Connexion à la base de données
     connexion = se_connecter_a_la_base_de_donnees(logger)
 
+    # On supprime les données temporaires
+    requete = f"DELETE FROM {nom_table}"
+    executer_requete(connexion, requete, logger)
+
     # Ensuite on charge les données
     requete = f"""
         INSERT INTO {nom_table}

--- a/transformation/clienteles.py
+++ b/transformation/clienteles.py
@@ -170,7 +170,18 @@ Vous devez vérifier les disciplines ci-dessous et vous assurer qu'elles sont da
             discipline,
             bibliotheque,
             clientele
-        FROM _tmp_etudiants;
+        FROM _tmp_etudiants
+        ON CONFLICT (journee, usager)
+        DO UPDATE SET
+            courriel = EXCLUDED.courriel,
+            codebarres = EXCLUDED.codebarres,
+            fonction = EXCLUDED.fonction,
+            niveau = EXCLUDED.niveau,
+            code_programme = EXCLUDED.code_programme,
+            programme = EXCLUDED.programme,
+            discipline = EXCLUDED.discipline,
+            bibliotheque = EXCLUDED.bibliotheque,
+            clientele = EXCLUDED.clientele;
     """
     executer_requete(connexion, requete, logger)
 
@@ -269,14 +280,19 @@ Vous devez vérifier les disciplines ci-dessous et vous assurer qu'elles sont da
             discipline,
             bibliotheque,
             clientele
-        FROM _tmp_personnel;
+        FROM _tmp_personnel
+        ON CONFLICT (journee, usager)
+        DO UPDATE SET
+            courriel = EXCLUDED.courriel,
+            codebarres = EXCLUDED.codebarres,
+            fonction = EXCLUDED.fonction,
+            code_unite = EXCLUDED.code_unite,
+            unite = EXCLUDED.unite,
+            niveau = EXCLUDED.niveau,
+            discipline = EXCLUDED.discipline,
+            bibliotheque = EXCLUDED.bibliotheque,
+            clientele = EXCLUDED.clientele;
     """
-    executer_requete(connexion, requete, logger)
-
-    # On supprime les données temporaires
-    requete = "DELETE FROM _tmp_personnel"
-    executer_requete(connexion, requete, logger)
-    requete = "DELETE FROM _tmp_etudiants"
     executer_requete(connexion, requete, logger)
 
     # Si nécessaire, on fait un chargement dans la table de clientèle

--- a/transformation/evenements.py
+++ b/transformation/evenements.py
@@ -44,7 +44,16 @@ try:
         SELECT e.id, e.title, CAST(e.start AS DATE), e.owner, e.presenter, COUNT(i.email) AS nb_participants
         FROM _tmp_evenements e
         LEFT JOIN _tmp_inscriptions i ON e.id = i.event_id
-        GROUP BY e.id;
+        GROUP BY e.id
+        ON CONFLICT (id)
+        DO UPDATE SET
+            titre = EXCLUDED.titre,
+            journee = EXCLUDED.journee,
+            proprietaire = EXCLUDED.proprietaire,
+            presentateur = EXCLUDED.presentateur,
+            nb_participants = EXClUDED.nb_participants,
+            session = NULL
+            ;
     """
     executer_requete(connexion, requete, logger)
 
@@ -67,10 +76,6 @@ try:
             END
         WHERE session IS NULL;
     """
-    executer_requete(connexion, requete, logger)
-
-    # On supprime les données temporaires
-    requete = "DELETE FROM _tmp_evenements"
     executer_requete(connexion, requete, logger)
 
 finally:

--- a/transformation/inscriptions.py
+++ b/transformation/inscriptions.py
@@ -38,7 +38,11 @@ try:
     requete = """
         INSERT INTO inscriptions (id, courriel, evenement_id)
         SELECT e.booking_id, e.email, e.event_id
-        FROM _tmp_inscriptions e;
+        FROM _tmp_inscriptions e
+        ON CONFLICT (id, evenement_id)
+        DO UPDATE SET
+            courriel = EXCLUDED.courriel,
+            usager = NULL;
     """
     executer_requete(connexion, requete, logger)
 
@@ -47,13 +51,9 @@ try:
         UPDATE inscriptions i
         SET usager = c.usager, discipline = c.discipline
         FROM _clientele_cumul c
-        WHERE i.courriel = c.courriel;
+        WHERE i.courriel = c.courriel
+        AND i.usager = NULL;
     """
-    executer_requete(connexion, requete, logger)
-
-
-    # On supprime les données temporaires
-    requete = "DELETE FROM _tmp_inscriptions"
     executer_requete(connexion, requete, logger)
 
 finally:

--- a/utils/creation.py
+++ b/utils/creation.py
@@ -271,9 +271,6 @@ try:
                 Ouverture_session TIMESTAMP,
                 Fermeture_session TIMESTAMP,
                 Duree INTEGER,
-                courriel VARCHAR(255),
-                discipline VARCHAR(255),
-                bibliotheque VARCHAR(255),
                 CONSTRAINT pkey_{tmp_prefixe}{nom_table} PRIMARY KEY (id)
             );
         """
@@ -412,7 +409,6 @@ try:
         # Création de la table
         requete = f"""
             CREATE TABLE {nom_table} (
-                id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 ),
                 journee date,
                 usager VARCHAR(255),
                 courriel VARCHAR(255),
@@ -426,7 +422,8 @@ try:
                 unite VARCHAR(255),
                 discipline VARCHAR(255),
                 bibliotheque VARCHAR(100),
-                clientele BOOLEAN
+                clientele BOOLEAN,
+                CONSTRAINT pkey_{nom_table} PRIMARY KEY (journee, usager)
             );
         """
         executer_requete(connexion, requete, logger)


### PR DESCRIPTION
Cela permet notamment de re-transformer des données déjà chargées. Les suppressions de données dans les tables temporaires se font maintenant au début du chargement.

Aussi, on ne transforme plus de données dans les tables temporaires (pour qu'elles puissent être re-transformées).

À noter aussi que la table des _tmp_sessions_ordinateurs a été modifiée car des colonnes ne sont plus nécessaires.