### PR TITLE
Suppresion de champs non nécessaires

### DIFF
--- a/utils/creation.py
+++ b/utils/creation.py
@@ -283,9 +283,6 @@ try:
         requete = f"""
             CREATE TABLE {nom_table} (
                 usager VARCHAR(255),
-                courriel VARCHAR(255),
-                discipline VARCHAR(255),
-                bibliotheque VARCHAR(100),
                 session DATE,
                 journee DATE,
                 dateheure TIMESTAMP,


### PR DESCRIPTION
Ces champs avaient été supprimés de la table temporaire sessions_ordinateurs le 27 mai, mais pas de la table finale.